### PR TITLE
Provide correct function prototypes.

### DIFF
--- a/inc/os_applAPI.h
+++ b/inc/os_applAPI.h
@@ -880,7 +880,7 @@ uint8_t os_get_running_tid(void);
 
 uint8_t task_create( taskproctype taskproc, void *data, uint8_t prio, Msg_t* msgPool, uint8_t poolSize, uint16_t msgSize );
 void task_kill( uint8_t tid );
-void *task_get_data();
+void *task_get_data( void );
 Sem_t sem_bin_create( uint8_t initial );
 Sem_t sem_counting_create( uint8_t max, uint8_t initial );
 

--- a/inc/os_event.h
+++ b/inc/os_event.h
@@ -100,7 +100,7 @@ typedef struct {
 } EventQueue_t;
 
 
-void os_event_init();
+void os_event_init( void );
 void os_wait_event( uint8_t tid, Evt_t ev, uint8_t waitSingleEvent, uint32_t timeout );
 void os_wait_multiple( uint8_t waitAll, ...);
 void os_signal_event( Evt_t ev );

--- a/inc/os_msgqueue.h
+++ b/inc/os_msgqueue.h
@@ -134,7 +134,7 @@ enum {
 
 
 
-void os_msgQ_init();
+void os_msgQ_init( void );
 MsgQ_t os_msgQ_create( Msg_t *buffer, uint8_t nMessages, uint16_t msgSize,  uint8_t task_id );
 MsgQ_t os_msgQ_find( uint8_t task_id );
 //Sem_t os_msgQ_sem_get( MsgQ_t queue );


### PR DESCRIPTION
 Missing 'void' for function that does not take arguments causes warnings/errors when compiled with 'strict-prototypes' in GCC.