### PR TITLE
PR: new idea to utilize `os_on_assert`

### DIFF
--- a/inc/os_assert.h
+++ b/inc/os_assert.h
@@ -44,12 +44,11 @@
 extern "C" {
 #endif
 
-void os_on_assert( uint16_t line );
+void os_on_assert( const char* filename, uint16_t line, const char* expression);
+void os_on_assert_attach_callback( void (*callback)(const char*, uint16_t, const char*) );
 
 #ifndef NASSERT
-#define os_assert( test )   if ( !(test) ) {\
-                                os_on_assert(__LINE__);\
-                            }
+#define os_assert( test )   if ( !(test) ) {os_on_assert(__FILE__, __LINE__, #test);}
 #else
 #define os_assert( test )
 #endif

--- a/src/os_assert.c
+++ b/src/os_assert.c
@@ -37,14 +37,18 @@
 
 #include "cocoos.h"
 
-static void (*user_callback)(const char*, uint16_t, const char*);
+static void (*user_callback)(const char*, uint16_t, const char*) = (void*)0;
 
 void os_on_assert(const char* file, uint16_t line, const char* expr) {
     static volatile uint16_t l;
     os_disable_interrupts();
     l = line;
     l = l;
-    user_callback(file, line, expr);
+ 
+    if ( 0 != user_callback) {
+      user_callback(file, line, expr);
+    }
+ 
     while(1);
 }
 

--- a/src/os_assert.c
+++ b/src/os_assert.c
@@ -37,11 +37,18 @@
 
 #include "cocoos.h"
 
-void os_on_assert( uint16_t line ) {
+static void (*user_callback)(const char*, uint16_t, const char*);
+
+void os_on_assert(const char* file, uint16_t line, const char* expr) {
     static volatile uint16_t l;
     os_disable_interrupts();
     l = line;
     l = l;
+    user_callback(file, line, expr);
     while(1);
+}
+
+void os_on_assert_attach_callback(void (*callback)(const char*, uint16_t, const char*)) {
+    user_callback = callback;
 }
 

--- a/src/os_assert.c
+++ b/src/os_assert.c
@@ -45,7 +45,7 @@ void os_on_assert(const char* file, uint16_t line, const char* expr) {
     l = line;
     l = l;
  
-    if ( 0 != user_callback) {
+    if (0 != user_callback) {
       user_callback(file, line, expr);
     }
  


### PR DESCRIPTION
I've worked on `STM32f103 blue pill` and sometime, my code fell into `os_assert` loop.
After spending an amount of time, I borrowed the STM32duino assert macro and fixed the `os_assert` macro more debuggability by implement new attach function in `os_assert.h/.c`. 

Then, inserted to `os_on_assert_attach_callback` into my code:
```c++
os_on_assert_attach_callback(on_assert);
```

and I want to see the exception via serial output. so,
```c++
void on_assert(const char* filename, uint16_t line, const char* expr) {   
    while(!UART);
    while(1) {
        UART.print("Assert: ");
        UART.print(expr);
        UART.print(" ");
        UART.print(filename);
        UART.print(" Line ");
        UART.println(line);

        delay(1000);
    }
}
```
Finally, the serial output showed the cocoOs' exception:

`Assert: nTasks < N_TASKS .piolibdeps\cocoOS_ID5725\src\os_task.c Line 139`

Hope this PR could be useful.
Any feedback is welcome.
@ivankravets @ptrxt 