### PR TITLE
New port feature

### DIFF
--- a/inc/os_port.h
+++ b/inc/os_port.h
@@ -41,7 +41,26 @@
 //#define os_enable_interrupts()  __enable_irq()
 //#define os_disable_interrupts() __disable_irq()
 
+
+#define STRINGIZE(s) PRE_STRINGIZE(s)
+#define PRE_STRINGIZE(s) #s
+
+#if defined(PORT_INTERRUPT_HEADER)
+#include STRINGIZE(PORT_INTERRUPT_HEADER)
+#endif
+
+
+#if defined(PORT_INTE) && !defined(os_enable_interrupts)
+#define os_enable_interrupts() PORT_INTE
+#else
 #define os_enable_interrupts()
+#endif
+
+#if defined(PORT_INTD) && !defined(os_disable_interrupts)
+#define os_disable_interrupts() PORT_INTD
+#else
 #define os_disable_interrupts()
+#endif
+
 
 #endif

--- a/inc/os_port.h
+++ b/inc/os_port.h
@@ -52,13 +52,13 @@
 
 #if defined(PORT_INTE) && !defined(os_enable_interrupts)
 #define os_enable_interrupts() PORT_INTE
-#else
+#elif !defined(os_enable_interrupts)
 #define os_enable_interrupts()
 #endif
 
 #if defined(PORT_INTD) && !defined(os_disable_interrupts)
 #define os_disable_interrupts() PORT_INTD
-#else
+#elif !defined(os_disable_interrupts)
 #define os_disable_interrupts()
 #endif
 


### PR DESCRIPTION
This PR allows definition of macros _os_enable_interrupts()_ and _os_disable_interrupts()_ using compiler flags (-D). This allows to **port cocoOS to any architecture without modifying the header file inc/os_port.h**.

For that, 3 macros must be defined using compilation flags (`-D`):
- **PORT_INTERRUPT_HEADER**: header file required to enable/disable interrupts.
- **PORT_INTE**: routine or instruction that enables interrupts.
- **PORT_INTD**: routine or instruction that disables interrupts.
### AVR Example
For an AVR microcontroller using the "GNU GCC for AVR" compiler the values would be:
PORT_INTERRUPT_HEADER -> avr/interrupt.h
PORT_INTE -> sei()
PORT_INTD -> cli()
If you are using a Linux computer the compilation flags would be:
`-DPORT_INTERRUPT_HEADER=avr/interrupt.h -DPORT_INTE=sei\(\) -DPORT_INTD=cli\(\)`
On Windows and some IDEs compilation flags must be:
`-DPORT_INTERRUPT_HEADER=avr/interrupt.h -DPORT_INTE=sei\\\(\\\) -DPORT_INTD=cli\\\(\\\)`

### PIC Example
For an 8-bits PIC microcontroller using the "XC8" compiler the values would be:
PORT_INTERRUPT_HEADER -> xc.h
PORT_INTE -> ei()
PORT_INTD -> di()
Compilation flags:
`-DPORT_INTERRUPT_HEADER=xc.h -DPORT_INTE=ei\(\) -DPORT_INTD=di\(\)`

**Note**: The `\` character must appear before each parenthesis. In Windows and some IDEs it is necessary to use it three times for each parenthesis



